### PR TITLE
공통 유틸 - 날짜 포맷팅 #41

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,1 @@
+export type TDateForm = `${number}. ${string}. ${string}.`;

--- a/utils/date_formatter.ts
+++ b/utils/date_formatter.ts
@@ -1,0 +1,9 @@
+import type { TDateForm } from "@/types";
+
+export default function dateFormatter(date = new Date()): TDateForm {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${year}. ${month}. ${day}.`;
+}


### PR DESCRIPTION
## 고려 사항

timezone으로 저장되어있는 날짜를 유저에게 보여줄 형식으로 포멧팅 하는 유틸이 필요하였습니다.

다만 프로젝트 내에서 사용하는 날짜 형식이 한가지 종류를 사용하기 때문에 라이브러리를 하용하기에는 너무 오버 엔지니어링이라는 판단을 하였습니다.

## date_form 타입

날짜는 아래의 형식을 따릅니다.
```typescript
//  ex) `2025. 01. 25.`
export type TDateForm = `${number}. ${string}. ${string}.`;
```

## Interface

```
dateFormatter(date : Date) => `${number}. ${string}. ${string}.`
```

## 사용 방법

```typescript
import dateFormatter from "@/utils/date_formatter";

// 날짜를 넣지 않으면 지금 시간 자동 생성합니다.
const defaultDate = dateFormatter();

// 임의이 시간을 넣어줄 수 있지만 date 객체로 넘겨줘야합니다.
const newDate = dateFormatter(new Date("2025-01-25"));
```