### PR TITLE
공통 유틸 - uuid 생성 #42

### DIFF
--- a/utils/uuid_generator.ts
+++ b/utils/uuid_generator.ts
@@ -1,0 +1,3 @@
+export function uuidGenerator(): string {
+  return crypto.randomUUID();
+}


### PR DESCRIPTION
## 변경 사항 ##
- UUID를 생성하는 공통 유틸리티가 추가되었습니다.
## 필요성 ##
- carts 테이블 wrapper_item 컬럼의 uuid 식별자 생성을 위한 유틸리티 입니다.
  - 한 끼 묶음 카트를 통해 insert 되는 carts 데이터의 경우 해당 식별자를 필요로 합니다.
## 사용 예시 ##
```typescript
import { uuidGenerator } from "@/utils/uuid_generator";

const newUUID = uuidGenerator();

console.log(newUUID); // 예상 uuid value - 3e4cd46e-4a94-45c6-85d7-25216c44fc13
```