### PR TITLE
공통 컴포넌트 제작 - 카테고리 버튼 #14

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,6 +45,7 @@
         "type": "line-length",
         "order": "asc",
         "groups": [
+          "next",
           "react",
           "related-react",
           ["components"],
@@ -57,6 +58,7 @@
           ["internal"],
           ["shared"],
           ["utils"],
+          ["style"],
           ["type", "internal-type"],
           ["parent-type", "sibling-type", "index-type"],
           ["parent", "sibling", "index"],
@@ -67,6 +69,7 @@
         ],
         "custom-groups": {
           "value": {
+            "next" : ["next/**"],
             "react": ["react"],
             "related-react": ["react-*"],
             "hooks": "**/use-*",
@@ -76,7 +79,8 @@
             "entities" : "**/entities/**",
             "shared-components": "**/shared/*.tsx",
             "shared-hooks": "**/shared/use-*",
-            "utils": "**/utils/**"
+            "utils": "**/utils/**",
+            "style" : ["**/**.module.css", "**/style/**"]
           },
           "type": {
             "react": "react"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,7 +65,8 @@
           "side-effect",
           "style",
           "object",
-          "unknown"
+          "unknown",
+          "constants"
         ],
         "custom-groups": {
           "value": {
@@ -80,7 +81,8 @@
             "shared-components": "**/shared/*.tsx",
             "shared-hooks": "**/shared/use-*",
             "utils": "**/utils/**",
-            "style" : ["**/**.module.css", "**/style/**"]
+            "style" : ["**/**.module.css", "**/style/**"],
+            "constants" : "**/constants/**"
           },
           "type": {
             "react": "react"

--- a/components/common/category.module.css
+++ b/components/common/category.module.css
@@ -1,0 +1,30 @@
+.button {
+    /* button 기본 style 제거 */
+    border: none;
+    outline: none;
+    background-color: inherit ;
+    cursor: pointer;
+
+    /* a 기본 style 제거 */
+    color: inherit;
+    text-decoration-line: none;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.button:hover {
+    color: var(--secondary-color);
+}
+
+.image_wrapper {
+    width: 114px;
+    height: 114px;
+
+    margin-bottom: 10px;
+    border-radius: calc(infinity * 1px);
+
+    overflow: hidden;
+}

--- a/components/common/category.module.css
+++ b/components/common/category.module.css
@@ -1,4 +1,4 @@
-.button {
+.category__button {
     /* button 기본 style 제거 */
     border: none;
     outline: none;
@@ -15,11 +15,11 @@
     align-items: center;
 }
 
-.button:hover {
+.category__button:hover {
     color: var(--secondary-color);
 }
 
-.image_wrapper {
+.category__image__wrapper {
     width: 114px;
     height: 114px;
 

--- a/components/common/category.tsx
+++ b/components/common/category.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import Image from "next/image";
+
+import style from "@/components/common/category.module.css";
+
+import type { TCategory } from "@/constants/categories";
+
+interface CategoryProps {
+  category: TCategory;
+}
+
+export default function Category({ category }: CategoryProps) {
+  const { button, image_wrapper } = style;
+
+  return (
+    <li key={category.order}>
+      <Link className={button} href={`/category?value=${category.key}`}>
+        <div className={image_wrapper}>
+          <Image src={category.img} alt={category.key} width={114} height={114} />
+        </div>
+        <span className="text-md">{category.kor}</span>
+      </Link>
+    </li>
+  );
+}

--- a/components/common/category.tsx
+++ b/components/common/category.tsx
@@ -10,12 +10,12 @@ interface CategoryProps {
 }
 
 export default function Category({ category }: CategoryProps) {
-  const { button, image_wrapper } = style;
+  const { category__button, category__image__wrapper } = style;
 
   return (
     <li key={category.order}>
-      <Link className={button} href={`/category?value=${category.key}`}>
-        <div className={image_wrapper}>
+      <Link className={category__button} href={`/category?value=${category.key}`}>
+        <div className={category__image__wrapper}>
           <Image src={category.img} alt={category.key} width={114} height={114} />
         </div>
         <span className="text-md">{category.kor}</span>


### PR DESCRIPTION
공통 컴포넌트 제작 - 카테고리 버튼[#14](https://github.com/FRONT-END-BOOTCAMP-PLUS-3/haru-damu/issues/14) 구현을 완료하였습니다.

category 컴포넌트에서 사용되는 모든 노드들은 상수로 관리되기 때문에 CSR을 사용할 필요가 없어 `use client`를 지정해주지 않았습니다.
category 컴포넌트는 SSR로 랜더링 됩니다.

추가적으로 eslint 설정 중 import 그룹 설정을 세가지 추가하였습니다.
- next
- css
- constants

### 형태

![Jan-28-2025 16-38-13](https://github.com/user-attachments/assets/6d1d2ec5-ffc7-41a6-94bf-4bda9bdc68fd)

### Interface

- 하나의 category 정보를 받아 카드를 만듭니다. 

```typescript
interface CategoryProps {
  category: TCategory;
}

export type TCategory = {
  key: string;
  order: number;
  eng: string;
  kor: string;
  img: string;
};
```

### 사용 예시
```typescript
import CategoryList from "@/components/common/category";

import { CATEGORIES } from "@/constants/categories";

export default function Home() {
  return (
    <div>
      <main>메인이야야</main>
      {/* 추천 형태입니다. style은 자유롭게 설정 해주세요! */}
      <ul
        style={{
          padding: "40px",
          display: "flex",
          gap: "15px",
        }}
      >
        {CATEGORIES.map((category) => (
          <CategoryList key={category.order} category={category} />
        ))}
      </ul>
      <footer>푸터야</footer>
    </div>
  );
}
```