### PR TITLE
공통 유틸 - 유닛 타입 변환기 #24

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -21,7 +21,7 @@ export type TUser = {
   user_id: number;
   name: string;
   email: string;
-    created_at: string;
+  created_at: string;
   updated_at: string;
 };
 
@@ -54,3 +54,17 @@ export type THealth = {
   created_at: string; // ISO 날짜 형식
   updated_at: string; // ISO 날짜 형식
 };
+
+export type ValidConversions = {
+  g: "kg";
+  kg: "g";
+  ml: "l";
+  l: "ml";
+};
+
+export type FromUnit = keyof ValidConversions;
+export type ToUnit<U extends FromUnit> = ValidConversions[U];
+
+export type UnitConversion<U extends FromUnit> = `${U} -> ${ToUnit<U>}`;
+
+export type AllowedConversions = UnitConversion<FromUnit>;

--- a/utils/unit_converter.ts
+++ b/utils/unit_converter.ts
@@ -1,0 +1,30 @@
+import type { AllowedConversions, FromUnit, ToUnit } from "@/types";
+
+export const getConversionDirection = <U extends FromUnit>(from: U, to: ToUnit<U>) => {
+  return `${from} -> ${to}` as AllowedConversions;
+};
+
+const unitConverter = <U extends FromUnit>(from: U, to: ToUnit<U>, value: number) => {
+  const conversionDirection = getConversionDirection(from, to);
+
+  if ((conversionDirection === "g -> kg" || conversionDirection === "ml -> l") && value > 0.1) {
+    return {
+      unit: to,
+      value: value / 1000,
+    };
+  }
+
+  if ((conversionDirection === "kg -> g" || conversionDirection === "l -> ml") && value < 10000) {
+    return {
+      unit: to,
+      value: value * 1000,
+    };
+  }
+
+  return {
+    unit: from,
+    value,
+  };
+};
+
+export default unitConverter;


### PR DESCRIPTION
✨ 공통 유틸 - 유닛 타입 변환기[#24](https://github.com/FRONT-END-BOOTCAMP-PLUS-3/haru-damu/issues/24) 구현을 완료하였습니다.

### Interface

```typescript
export type ValidConversions = {
  g: "kg";
  kg: "g";
  ml: "l";
  l: "ml";
};

export type FromUnit = keyof ValidConversions;
export type ToUnit<U extends FromUnit> = ValidConversions[U];

export type UnitConversion<U extends FromUnit> = `${U} -> ${ToUnit<U>}`;

export type AllowedConversions = UnitConversion<FromUnit>;
```

### 사용 예시
```typescript
unitConverter('g', 'kg', 10000) // 결과값 { unit : 'kg', value : 10}
```