### PR TITLE
페이지 뷰 - 마이페이지 / 하루 권장 영양소 #26

### DIFF
--- a/app/(main)/cart/_components/cart.module.css
+++ b/app/(main)/cart/_components/cart.module.css
@@ -1,11 +1,24 @@
+.cart_wrapper {
+    height: fit-content;
+
+    background: #fff;
+
+    position: relative;
+}
+
+.cart_wrapper__shrunk {
+    padding-top: 420px;
+}
 
 .cart__fixed {
     width: 1080px;
 
     background: var(--base-white);
 
-    position: fixed;
-    top: 0;
-
     z-index: 500;
+}
+
+.cart__shrunk__top {
+    position: fixed;
+    top: 80px;
 }

--- a/app/(main)/cart/_components/cart.tsx
+++ b/app/(main)/cart/_components/cart.tsx
@@ -4,6 +4,7 @@ import MealCart from "@/app/(main)/cart/_components/meal_cart";
 import CartLists from "@/app/(main)/cart/_components/cart_lists";
 import CartListHeader from "@/app/(main)/cart/_components/cart_list_header";
 
+import { useStore } from "@/hooks/usestore";
 import useDndContext from "@/hooks/use_dnd_context";
 
 import style from "@/app/(main)/cart/_components/cart.module.css";
@@ -22,6 +23,8 @@ interface CartProps {
 }
 
 export default function Cart({ items }: CartProps) {
+  const { isShrunk } = useStore();
+
   const { sensors, onDragEnd, onDragOver, onDragStart, onDragCancel, overlayElement } = useDndContext();
 
   const dropAnimation: DropAnimation = {
@@ -47,19 +50,21 @@ export default function Cart({ items }: CartProps) {
   };
 
   return (
-    <DndContext
-      sensors={sensors}
-      onDragEnd={onDragEnd}
-      onDragOver={onDragOver}
-      onDragStart={onDragStart}
-      onDragCancel={onDragCancel}
-    >
-      <div className={cx("cart__fixed")}>
-        <MealCart />
-        <CartListHeader />
-      </div>
-      <CartLists items={items} />
-      <DragOverlay dropAnimation={dropAnimation}>{overlayElement}</DragOverlay>
-    </DndContext>
+    <div className={cx("cart_wrapper", "container", isShrunk && "cart_wrapper__shrunk")}>
+      <DndContext
+        sensors={sensors}
+        onDragEnd={onDragEnd}
+        onDragOver={onDragOver}
+        onDragStart={onDragStart}
+        onDragCancel={onDragCancel}
+      >
+        <div className={cx("cart__fixed", isShrunk && "cart__shrunk__top")}>
+          <MealCart />
+          <CartListHeader />
+        </div>
+        <CartLists items={items} />
+        <DragOverlay dropAnimation={dropAnimation}>{overlayElement}</DragOverlay>
+      </DndContext>
+    </div>
   );
 }

--- a/app/(main)/cart/_components/meal_cart.tsx
+++ b/app/(main)/cart/_components/meal_cart.tsx
@@ -19,6 +19,7 @@ import classNames from "classnames/bind";
 import { useDroppable } from "@dnd-kit/core";
 import { ArrowLeftCircle, ArrowRightCircle } from "lucide-react";
 import { horizontalListSortingStrategy, SortableContext } from "@dnd-kit/sortable";
+import { REMOVE_ALL_MEAL_ITEMS_BUTTON, WRAPPING_ALL_MEAL_ITEMS_BUTTON } from "@/constants";
 
 const cx = classNames.bind(style);
 
@@ -64,9 +65,6 @@ export default function MealCart() {
       sugar,
     };
   });
-
-  const WRAPPING_ALL_MEAL_ITEMS_BUTTON = "한끼 장바구니 그룹화 하기";
-  const REMOVE_ALL_MEAL_ITEMS_BUTTON = "한끼 장바구니 모두 제거";
 
   useEffect(() => {
     const getCarouselItems = (items: TCartItem[], page: number, pageSize = 4): TCartItem[] => {

--- a/app/(main)/cart/page.module.css
+++ b/app/(main)/cart/page.module.css
@@ -1,7 +1,0 @@
-.cart_wrapper {
-    height: fit-content;
-    
-    padding-top: 400px;
-
-    background: #fff;
-}

--- a/app/(main)/cart/page.tsx
+++ b/app/(main)/cart/page.tsx
@@ -1,20 +1,10 @@
 import Cart from "@/app/(main)/cart/_components/cart";
 
-import style from "@/app/(main)/cart/page.module.css";
-
-import classNames from "classnames/bind";
-
-const cx = classNames.bind(style);
-
 export default async function CartPage() {
   const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "";
 
   const fetchedItems = await fetch(`${BASE_URL}/api/carts`);
   const cartItems = await fetchedItems.json();
 
-  return (
-    <div className={cx("cart_wrapper", "container")}>
-      <Cart items={cartItems} />
-    </div>
-  );
+  return <Cart items={cartItems} />;
 }

--- a/app/(main)/category/page.tsx
+++ b/app/(main)/category/page.tsx
@@ -1,9 +1,10 @@
+import CategoryResult from "@/app/(main)/category/_components/category_result";
+
 import getBlurImg from "@/utils/get_blur_img";
 
 import type { TItem } from "@/types";
 
 import items from "@/dummys/items";
-import CategoryResult from "@/app/(main)/category/_components/category_result";
 
 export default async function CategoryPage({ searchParams }: { searchParams: { page?: string } }) {
   const itemsPerPage = 20;

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -4,12 +4,16 @@ import type { ReactNode } from "react";
 
 import Footer from "@/components/common/footer";
 import Header from "@/components/common/header";
+import ToastContainer from "@/components/common/toastContainer";
 
 export default function MainLayout({ children }: { children: ReactNode }) {
   return (
     <div>
       <Header />
-      <main>{children}</main>
+      <main>
+        {children}
+        <ToastContainer />
+      </main>
       <Footer />
     </div>
   );

--- a/app/(main)/mypage/_components/nutrition.tsx
+++ b/app/(main)/mypage/_components/nutrition.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+
+import NutritionInfo from "@/app/(main)/mypage/_components/nutrition_info";
+import NutritionChart from "@/app/(main)/mypage/_components/nutrition_chart";
+
+import { useStore } from "@/hooks/usestore";
+
+import { MYPAGE_NUTRITION_LIST } from "@/constants/mypage";
+
+import type { THealth } from "@/types";
+import type { TMypageNutrition } from "@/stores/mypage_store";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "";
+
+export default function Nutrition() {
+  const { setUserNutrition, setIsCustom } = useStore();
+
+  const fetchNutrition = async () => {
+    const fetchedNutrition = await fetch(`${BASE_URL}/api/nutrition`);
+
+    const {
+      recommendedNutrition: { total: recommendedNutrition },
+      customNutrition,
+    } = await fetchedNutrition.json();
+
+    const newNutrition: TMypageNutrition[] = MYPAGE_NUTRITION_LIST.map((nutrition) => {
+      return {
+        ...nutrition,
+        value: customNutrition[nutrition.key as keyof THealth] as number,
+        recommendValue: Math.ceil(recommendedNutrition[nutrition.key as keyof THealth] as number),
+      };
+    });
+
+    setIsCustom(customNutrition.is_custom);
+    setUserNutrition(newNutrition);
+  };
+
+  useEffect(() => {
+    fetchNutrition();
+  }, []);
+
+  return (
+    <div>
+      <NutritionChart />
+      <NutritionInfo />
+    </div>
+  );
+}

--- a/app/(main)/mypage/_components/nutrition_bar.module.css
+++ b/app/(main)/mypage/_components/nutrition_bar.module.css
@@ -1,0 +1,43 @@
+.nutrition_bar__wrapper {
+    width: 100%;
+
+    box-sizing: border-box;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+
+    box-sizing: border-box;
+}
+
+.nutrition_bar {
+    width: 300px;
+    height: 400px;
+}
+
+.nutrition_bar__ul {
+    width: 70%;
+
+    padding-top: 20px;
+
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);  /* 두 개의 열 */
+    gap: 10px;
+}
+
+.nutrition_bar__list {
+    padding: 5px;
+
+    display: flex;
+    flex-direction: row;
+}
+
+.nutrition_bar__list__div {
+    width: 14px;
+    height: 14px;
+
+    margin-right: 5px;
+
+    border-radius: 50%;
+}

--- a/app/(main)/mypage/_components/nutrition_bar.tsx
+++ b/app/(main)/mypage/_components/nutrition_bar.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { Bar } from "react-chartjs-2";
+
+import { useStore } from "@/hooks/usestore";
+
+import style from "@/app/(main)/mypage/_components/nutrition_bar.module.css";
+
+import type { Context } from "chartjs-plugin-datalabels";
+
+import classNames from "classnames/bind";
+import ChartDataLabels from "chartjs-plugin-datalabels";
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Tooltip, Legend } from "chart.js";
+
+const cx = classNames.bind(style);
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend, ChartDataLabels);
+
+export default function NutritionBar() {
+  const { isCustom, userNutrition } = useStore();
+
+  const labels = userNutrition.map((data) => data.label);
+
+  const calculatePercentage = (value = 1, total = 1): number => {
+    if (value === 0 || total === 0) return 0;
+
+    return Math.floor((value / total) * 100);
+  };
+
+  const dayNutrition = userNutrition.map((nutrition) => {
+    return {
+      ...nutrition,
+      percent: isCustom ? calculatePercentage(nutrition.value, nutrition.recommendValue) : 100,
+    };
+  });
+
+  const data = dayNutrition.map((data) => data.percent);
+  const backgroundColor = dayNutrition.map((data) => {
+    if (data.percent === 100) return "#228B22";
+
+    if (data.percent < 30 && data.percent > 140) return "##FF9F40";
+    if (data.percent < 70 && data.percent > 50) return "##FFCE56";
+    if (data.percent < 120 && data.percent > 71) return "#32CD32";
+
+    return "#FF6384";
+  });
+
+  const chartData = {
+    labels,
+    datasets: [
+      {
+        data,
+        backgroundColor,
+      },
+    ],
+  };
+
+  const options = {
+    indexAxis: "x" as const,
+    responsive: true,
+    plugins: {
+      legend: {
+        display: false,
+      },
+      maintainAspectRatio: false,
+      datalabels: {
+        color: "black",
+        anchor: "center" as const,
+        display: (context: Context) => {
+          const chart = context.chart;
+          const dataset = chart.data.datasets[context.datasetIndex];
+          const isTotalLabel = dataset.data.length > 1 && context.dataIndex === dataset.data.length - 1;
+          return !isTotalLabel;
+        },
+        formatter: (value: number) => `${value}%`,
+      },
+    },
+    scales: {
+      x: {
+        ticks: {
+          color: "black",
+        },
+      },
+      y: {
+        max: 200,
+        beginAtZero: true,
+        reverse: false,
+        ticks: {
+          color: "black",
+        },
+      },
+    },
+  };
+
+  return (
+    <div className={cx("nutrition_bar__wrapper")}>
+      <Bar height={"270px"} options={options} data={chartData} />
+      <ul className={cx("nutrition_bar__ul")}>
+        {dayNutrition.map((data, idx) => (
+          <li key={idx} className={cx("nutrition_bar__list")}>
+            <div className={cx("nutrition_bar__list__div")} style={{ background: backgroundColor[idx] }} />
+            <span>{`${data.label}`}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/(main)/mypage/_components/nutrition_chart.module.css
+++ b/app/(main)/mypage/_components/nutrition_chart.module.css
@@ -1,0 +1,42 @@
+.nutrition_chart__wrapper {
+    width: 100%;
+    max-width: 1080px;
+    height: fit-content;
+
+    padding: 50px 30px;
+
+    border: 1px solid var(--secondary-color);
+    border-radius: 10px;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    box-sizing: border-box;
+}
+
+.nutrition_chart__flex {
+    width: 100%;
+    height: 100%;
+
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+
+    gap: 30px;
+}
+
+.nutrition_chart__div {
+    width: 100%;
+    height: 100%;
+
+    margin-top: 40px;
+
+    flex: 1;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    gap: 20px;
+}

--- a/app/(main)/mypage/_components/nutrition_chart.tsx
+++ b/app/(main)/mypage/_components/nutrition_chart.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import NutritionBar from "@/app/(main)/mypage/_components/nutrition_bar";
+import NutritionPie from "@/app/(main)/mypage/_components/nutrition_pie";
+
+import style from "@/app/(main)/mypage/_components/nutrition_chart.module.css";
+
+import { NUTRITION_CHART_TITLE } from "@/constants/mypage";
+
+import classNames from "classnames/bind";
+
+const cx = classNames.bind(style);
+
+export const CUSTOM_CHART_TITLE = "현재 영양소 비율";
+export const PERCENT_CHART_TITLE = "권장 영양소와 현재 영양소 비교(%)";
+
+export default function NutritionChart() {
+  return (
+    <div className={cx("nutrition_chart__wrapper")}>
+      <span className="title-lg-b">{NUTRITION_CHART_TITLE}</span>
+      <div className={cx("nutrition_chart__flex")}>
+        <div className={cx("nutrition_chart__div")}>
+          <div className="title-sm">{CUSTOM_CHART_TITLE}</div>
+          <NutritionPie />
+        </div>
+        <div className={cx("nutrition_chart__div")}>
+          <div className="title-sm">{PERCENT_CHART_TITLE}</div>
+          <NutritionBar />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/mypage/_components/nutrition_info.module.css
+++ b/app/(main)/mypage/_components/nutrition_info.module.css
@@ -1,0 +1,123 @@
+.nutrition_info {
+    width: 100%;
+
+    padding-top: 100px;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+
+    position: relative;
+}
+
+.nutrition_info__ul {
+    width: 100%;
+
+    display: flex;
+    flex-direction: row;
+    flex-wrap : wrap;
+    align-items: center;
+    justify-content: center;
+}
+
+.nutrition_info__li {
+    min-width: 35%;
+
+    padding: 10px 20px;
+}
+
+.nutrition_info__approve_button {
+    margin: 20px;
+}
+
+.nutrition_info__toggle__wrapper {
+    display: flex;
+    justify-content: end;
+    align-items: center;
+
+    position: absolute;
+    top: 60px;
+    right: 5px;
+}
+
+.nutrition_info__toggle__span {
+    padding: 0px 10px;
+
+    color: var(--base-content-sub-text);
+}
+
+.nutrition_info__toggle {
+    width: 80px;
+    height: 40px;
+
+    border-radius: 9999px;
+    background: var(--base-content-sub-text); /* 기본 배경색 */
+
+    cursor: pointer;
+
+    transition: background-color 0.3s ease;
+
+    position: relative;
+}
+
+.nutrition_info__toggle_circle {
+    width: 32px;
+    height: 32px;
+    
+    border-radius: 50%;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+
+    background-color: white;
+
+    transition: transform 0.3s ease;
+
+    position: absolute;
+    top: 4px;
+    left: 4px;
+}
+
+.nutrition_info__toggle_text {
+    width: 32px;
+    height: 32px;
+
+    padding: 0px 2px;
+
+    color: var(--base-white);
+    
+    transition: transform 0.3s ease;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    position: absolute;
+    top: 4px;
+    left: 4px;
+}
+
+/* 왼쪽(초록색) 상태 */
+.nutrition_info__toggle_active {
+    background-color: var(--secondary-color);
+}
+
+.nutrition_info__toggle_active .nutrition_info__toggle_circle {
+    transform: translateX(0); 
+}
+
+.nutrition_info__toggle_active .nutrition_info__toggle_text {
+    transform: translateX(35px); 
+}
+
+/* 오른쪽(회색) 상태 */
+.nutrition_info__toggle_inactive {
+    background-color: var(--base-content-sub-text);
+}
+
+.nutrition_info__toggle_inactive .nutrition_info__toggle_circle {
+    transform: translateX(40px);
+}
+
+.nutrition_info__toggle_inactive .nutrition_info__toggle_text {
+    transform: translateX(0px);
+}

--- a/app/(main)/mypage/_components/nutrition_info.tsx
+++ b/app/(main)/mypage/_components/nutrition_info.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import Input from "@/components/common/input";
+import Button from "@/components/common/button";
+
+import { useStore } from "@/hooks/usestore";
+
+import style from "@/app/(main)/mypage/_components/nutrition_info.module.css";
+
+import { APPROVE, CUSTOM_TEXT, EDIT, FIX, FIX_TEXT } from "@/constants/mypage";
+
+import type { TMypageNutrition } from "@/stores/mypage_store";
+
+import classNames from "classnames/bind";
+import { ERROR_MESSAGE, UPDATE_SUCCESS_MESSAGE } from "@/constants";
+
+const cx = classNames.bind(style);
+
+export default function NutritionInfo() {
+  const { addMessage, isCustom, setIsCustom, userNutrition, updateUserNutrition } = useStore();
+
+  const toggleHandler = () => {
+    setIsCustom(!isCustom);
+  };
+
+  const onChangeHandler = (key: keyof TMypageNutrition, value: string) => {
+    console.log(value, typeof value);
+
+    if (value.replace(/[^a-zA-Z]/g, "")) return addMessage("숫자만 입력해주세요!", "var(--important-color)");
+
+    updateUserNutrition(key, Number(value));
+  };
+
+  const onClickHandler = () => {
+    const handleUpdate = async () => {
+      try {
+        await fetch("/api/nutrition", {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(userNutrition),
+        });
+
+        addMessage(UPDATE_SUCCESS_MESSAGE);
+      } catch (error) {
+        addMessage(ERROR_MESSAGE);
+        console.error(error);
+      }
+    };
+
+    handleUpdate();
+  };
+
+  return (
+    <div className={cx("nutrition_info")}>
+      {/* toggle */}
+      <div className={cx("nutrition_info__toggle__wrapper")}>
+        <span className={cx("nutrition_info__toggle__span")}>{isCustom ? FIX_TEXT : CUSTOM_TEXT}</span>
+        <div
+          className={cx(
+            "nutrition_info__toggle",
+            isCustom ? "nutrition_info__toggle_active" : "nutrition_info__toggle_inactive",
+          )}
+          onClick={toggleHandler}
+        >
+          <span className={cx("nutrition_info__toggle_text", "text-md-b")}>{isCustom ? EDIT : FIX}</span>
+          <div className={cx("nutrition_info__toggle_circle")}></div>
+        </div>
+      </div>
+      {/* input area */}
+      <ul className={cx("nutrition_info__ul")}>
+        {userNutrition.map((nutrition, idx) => (
+          <li key={idx} className={cx("nutrition_info__li")}>
+            <Input
+              label={`${nutrition.label}(${nutrition.unit})`}
+              inputValue={isCustom ? nutrition.value : nutrition.recommendValue}
+              disabled={!isCustom}
+              onChange={(value) => {
+                onChangeHandler(nutrition.key as keyof TMypageNutrition, value as string);
+              }}
+            />
+          </li>
+        ))}
+      </ul>
+      {isCustom && (
+        <Button text={APPROVE} width="50%" className={cx("nutrition_info__approve_button")} onClick={onClickHandler} />
+      )}
+    </div>
+  );
+}

--- a/app/(main)/mypage/_components/nutrition_pie.module.css
+++ b/app/(main)/mypage/_components/nutrition_pie.module.css
@@ -1,0 +1,31 @@
+.nutrition_pie__wrapper {
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.nutrition_pie__ul {
+    padding-top: 20px;
+
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);  /* 두 개의 열 */
+    gap: 10px;
+}
+
+.nutrition_pie__list {
+    padding: 5px;
+
+    display: flex;
+    flex-direction: row;
+}
+
+.nutrition_pie__list__div {
+    width: 14px;
+    height: 14px;
+
+    margin-right: 5px;
+
+    border-radius: 50%;
+}

--- a/app/(main)/mypage/_components/nutrition_pie.tsx
+++ b/app/(main)/mypage/_components/nutrition_pie.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Pie } from "react-chartjs-2";
+
+import { useStore } from "@/hooks/usestore";
+
+import unitConverter from "@/utils/unit_converter";
+
+import style from "@/app/(main)/mypage/_components/nutrition_pie.module.css";
+
+import { MYPAGE_NUTRITION_CHART_COLOR } from "@/constants/mypage";
+
+import classNames from "classnames/bind";
+import { Chart as ChartJS, ArcElement, Tooltip } from "chart.js";
+
+ChartJS.register(Tooltip, ArcElement);
+
+const cx = classNames.bind(style);
+
+export default function NutritionPie() {
+  const { isCustom, userNutrition } = useStore();
+
+  const legends = userNutrition
+    .filter((data) => data.key !== "calorie")
+    .map((data) => {
+      if (data.key === "sodium")
+        return {
+          ...data,
+          value: isCustom
+            ? unitConverter("mg", "g", data.value).value
+            : unitConverter("mg", "g", data.recommendValue).value,
+          color: MYPAGE_NUTRITION_CHART_COLOR[data.key as keyof typeof MYPAGE_NUTRITION_CHART_COLOR],
+        };
+
+      return {
+        ...data,
+        value: isCustom ? data.value : data.recommendValue,
+        color: MYPAGE_NUTRITION_CHART_COLOR[data.key as keyof typeof MYPAGE_NUTRITION_CHART_COLOR],
+      };
+    });
+
+  const labels = legends.map((data) => data.label);
+  const backgroundColor = legends.map((data) => data.color);
+  const values = legends.map((data) => data.value);
+
+  const options = {
+    plugins: {
+      legend: {
+        display: false,
+      },
+      datalabels: {
+        display: false,
+      },
+    },
+  };
+
+  const pieData = {
+    labels,
+    datasets: [
+      {
+        data: values,
+        backgroundColor: backgroundColor,
+        borderWidth: 4,
+      },
+    ],
+  };
+
+  return (
+    <div className={cx("nutrition_pie__wrapper")}>
+      <Pie options={options} data={pieData} />
+      <ul className={cx("nutrition_pie__ul")}>
+        {legends.map((legend, idx) => (
+          <li key={idx} className={cx("nutrition_pie__list")}>
+            <div className={cx("nutrition_pie__list__div")} style={{ background: legend.color }} />
+            <span>{`${legend.label}`}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,4 +1,6 @@
 import Category from "@/components/common/category";
+import Banner from "@/app/(main)/_components/banner";
+import MealList from "@/app/(main)/_components/meal_list";
 
 import styles from "@/app/(main)/main_page.module.css";
 
@@ -7,8 +9,6 @@ import { CATEGORIES } from "@/constants/categories";
 
 import classNames from "classnames/bind";
 import { dummyItems } from "@/dummys/items";
-import Banner from "@/app/(main)/_components/banner";
-import MealList from "@/app/(main)/_components/meal_list";
 
 const cx = classNames.bind(styles);
 

--- a/app/api/nutrition/route.ts
+++ b/app/api/nutrition/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 
 import { calcOneMeals } from "@/utils/onemeal_kcal";
 
+import type { NextRequest } from "next/server";
+
 import health from "@/dummys/health";
 
 export async function GET() {
@@ -43,4 +45,19 @@ export async function GET() {
     recommendedNutrition,
     customNutrition,
   });
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const { id, newData } = await request.json();
+
+    // 데이터베이스 업데이트 로직
+    // await updateUserData(id, newData);
+
+    // 응답 반환 (NextResponse 사용)
+    return NextResponse.json({ message: "User data updated successfully." }, { status: 200 });
+  } catch (error) {
+    // 오류 처리 및 응답 반환
+    return NextResponse.json({ message: "Error updating user data." }, { status: 500 });
+  }
 }

--- a/app/api/nutrition/route.ts
+++ b/app/api/nutrition/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+
+import { calcOneMeals } from "@/utils/onemeal_kcal";
+
+import health from "@/dummys/health";
+
+export async function GET() {
+  const {
+    weight,
+    height,
+    age,
+    gender_code: gender,
+    activity_code: activityLevel,
+    is_custom,
+    calorie,
+    carbohydrates,
+    protein,
+    fat,
+    sodium,
+    sugar,
+  } = health;
+
+  const userInfo = {
+    weight,
+    height,
+    age,
+    gender,
+    activityLevel,
+  };
+  const recommendedNutrition = calcOneMeals(weight, height, age, gender, activityLevel);
+  const customNutrition = {
+    is_custom,
+    calorie,
+    carbohydrates,
+    protein,
+    fat,
+    sodium,
+    sugar,
+  };
+
+  return NextResponse.json({
+    userInfo,
+    recommendedNutrition,
+    customNutrition,
+  });
+}

--- a/components/common/header.tsx
+++ b/components/common/header.tsx
@@ -2,26 +2,33 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 
-import { useState, useEffect, useCallback } from "react";
+import { useEffect, useCallback } from "react";
 
 import SearchBar from "@/components/searchbar";
 import CategoryList from "@/components/category_list";
+
+import { useStore } from "@/hooks/usestore";
+
 import styles from "@/components/common/header.module.css";
 
 import categoryList from "@/constants/categories_list";
 
 import classNames from "classnames/bind";
 import { BRAND_NAMES } from "@/constants";
-import { useStore } from "@/hooks/usestore";
 import { ShoppingBasket, User } from "lucide-react";
 
 const cx = classNames.bind(styles);
 
 export default function Header() {
-  const { isLogin, userType } = useStore();
-  const [isShrunk, setIsShrunk] = useState(false);
+  const { isLogin, userType, isShrunk, setIsShrunk } = useStore();
 
-  const handleScroll = useCallback(() => setIsShrunk(window.scrollY > 100), []);
+  const handleScroll = useCallback(() => {
+    const y = window.scrollY;
+
+    if (y > 200) return;
+
+    setIsShrunk(y > 100);
+  }, []);
 
   useEffect(() => {
     window.addEventListener("scroll", handleScroll);

--- a/components/common/user_aside.tsx
+++ b/components/common/user_aside.tsx
@@ -2,6 +2,8 @@
 
 import { Pie } from "react-chartjs-2";
 
+import { useStore } from "@/hooks/usestore";
+
 import style from "@/components/common/user_aside.module.css";
 
 import { ASIDE_PATH, HEALTH_CHART_DATA, HONORIFIC_TEXT, NUTRITION_TITLE, WELCOME_TEXT } from "@/constants/aside";
@@ -10,7 +12,6 @@ import type { THealth, TUser } from "@/types";
 import type { TMypagePath } from "@/stores/mypage_store";
 
 import classNames from "classnames/bind";
-import { useStore } from "@/hooks/usestore";
 import { Chart as ChartJS, ArcElement, Tooltip } from "chart.js";
 
 const cx = classNames.bind(style);

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -25,3 +25,9 @@ export const MAIN_MEAL = {
 
 export const DRAGGABLE_TYPES = ["cart-item", "meal-cart-item"] as const;
 export const DROPPABLE_ONLY_TYPES = ["cart-list-box", "meal-cart-area"] as const;
+
+export const WRAPPING_ALL_MEAL_ITEMS_BUTTON = "한끼 장바구니 그룹화 하기";
+export const REMOVE_ALL_MEAL_ITEMS_BUTTON = "한끼 장바구니 모두 제거";
+
+export const UPDATE_SUCCESS_MESSAGE = "업데이트에 성공하였습니다.";
+export const ERROR_MESSAGE = "죄송합니다! 잠시 후 다시 시도 해주세요!";

--- a/constants/mypage.ts
+++ b/constants/mypage.ts
@@ -1,0 +1,51 @@
+export const EDIT = "수정";
+export const FIX = "고정";
+
+export const APPROVE = "변경하기";
+
+export const CUSTOM_TEXT = "영양소 값 커스텀 하기 ->";
+export const FIX_TEXT = "권장 영양소 값으로 계산 하기 ->";
+
+export const NUTRITION_CHART_TITLE = "하루 영양소";
+
+export const MYPAGE_NUTRITION_LIST = [
+  {
+    key: "calorie",
+    label: "칼로리",
+    unit: "kcal",
+  },
+  {
+    key: "carbohydrates",
+    label: "탄수화물",
+    unit: "g",
+  },
+  {
+    key: "protein",
+    label: "단백질",
+    unit: "g",
+  },
+  {
+    key: "fat",
+    label: "지방",
+    unit: "g",
+  },
+  {
+    key: "sodium",
+    label: "나트륨",
+    unit: "mg",
+  },
+  {
+    key: "sugar",
+    label: "당",
+    unit: "g",
+  },
+];
+
+export const MYPAGE_NUTRITION_CHART_COLOR: Record<string, string> = {
+  calorie: "#FF6384", // 연한 빨강 - 칼로리
+  protein: "#36A2EB", // 밝은 파랑 - 단백질
+  carbohydrates: "#FFCE56", // 밝은 노랑 - 탄수화물
+  fat: "#FF9F40", // 주황 - 지방
+  sugar: "#9966FF", // 보라 - 당류
+  sodium: "#4BC0C0", // 청록 - 나트륨
+} as const;

--- a/dummys/health.ts
+++ b/dummys/health.ts
@@ -11,7 +11,7 @@ const health: THealth = {
   carbohydrates: 334,
   protein: 167,
   fat: 74,
-  sodium: 2.3,
+  sodium: 2300,
   sugar: 50,
   is_custom: false,
   created_at: "2025-01-24T12:00:00",

--- a/stores/mypage_store.ts
+++ b/stores/mypage_store.ts
@@ -3,14 +3,32 @@ import type { State } from "@/hooks/usestore";
 
 export type TMypagePath = "nutrition" | "personal" | "health" | "order";
 
-export type TMypageSlice = {
-  mypagePath: TMypagePath;
+export type TMypageNutrition = {
+  key: string;
+  label: string;
+  unit: string;
+  value: number;
+  recommendValue: number;
+};
 
+export type TMypageSlice = {
+  //aside
+  mypagePath: TMypagePath;
   setMypagePath: (mypagePath: TMypagePath) => void;
+
+  //nutrition
+  userNutrition: TMypageNutrition[];
+  setUserNutrition: (userNutrition: TMypageNutrition[]) => void;
 };
 
 export const createMypageSlice: StateCreator<Partial<State>, [], [], TMypageSlice> = (set, get) => ({
+  //aside
   mypagePath: "nutrition",
 
   setMypagePath: (mypagePath) => set({ mypagePath }),
+
+  //nutrition
+  userNutrition: [],
+
+  setUserNutrition: (userNutrition) => set({ userNutrition }),
 });

--- a/stores/mypage_store.ts
+++ b/stores/mypage_store.ts
@@ -17,8 +17,11 @@ export type TMypageSlice = {
   setMypagePath: (mypagePath: TMypagePath) => void;
 
   //nutrition
+  isCustom: boolean;
   userNutrition: TMypageNutrition[];
+  setIsCustom: (isCustom: boolean) => void;
   setUserNutrition: (userNutrition: TMypageNutrition[]) => void;
+  updateUserNutrition: (key: keyof TMypageNutrition, value: number) => void;
 };
 
 export const createMypageSlice: StateCreator<Partial<State>, [], [], TMypageSlice> = (set, get) => ({
@@ -28,7 +31,25 @@ export const createMypageSlice: StateCreator<Partial<State>, [], [], TMypageSlic
   setMypagePath: (mypagePath) => set({ mypagePath }),
 
   //nutrition
+  isCustom: false,
   userNutrition: [],
 
+  setIsCustom: (isCustom) =>
+    set({
+      isCustom,
+    }),
   setUserNutrition: (userNutrition) => set({ userNutrition }),
+  updateUserNutrition: (key, value) =>
+    set(() => {
+      return {
+        userNutrition: get().userNutrition?.map((nutrition) => {
+          if (nutrition.key === key)
+            return {
+              ...nutrition,
+              value,
+            };
+          return nutrition;
+        }),
+      };
+    }),
 });

--- a/stores/user_store.ts
+++ b/stores/user_store.ts
@@ -4,13 +4,17 @@ import type { State } from "@/hooks/usestore";
 export type TUserSlice = {
   isLogin: boolean;
   userType: "user" | "partner" | null;
+  isShrunk: boolean;
+
   login: (type: "user" | "partner") => void;
   logout: () => void;
+  setIsShrunk: (isShrunk: boolean) => void;
 };
 
 export const createUserSlice: StateCreator<Partial<State>, [], [], TUserSlice> = (set) => ({
   isLogin: false,
   userType: null,
+  isShrunk: false,
 
   login: (type) =>
     set((state) => ({
@@ -25,4 +29,6 @@ export const createUserSlice: StateCreator<Partial<State>, [], [], TUserSlice> =
       isLoggedIn: false,
       userType: null,
     })),
+
+  setIsShrunk: (isShrunk) => set({ isShrunk }),
 });

--- a/types/index.ts
+++ b/types/index.ts
@@ -71,6 +71,7 @@ export type THealth = {
 
 // unit_converter ===================================================================
 export type ValidConversions = {
+  mg:'g';
   g: "kg";
   kg: "g";
   ml: "l";

--- a/utils/unit_converter.ts
+++ b/utils/unit_converter.ts
@@ -7,7 +7,10 @@ export const getConversionDirection = <U extends FromUnit>(from: U, to: ToUnit<U
 const unitConverter = <U extends FromUnit>(from: U, to: ToUnit<U>, value: number) => {
   const conversionDirection = getConversionDirection(from, to);
 
-  if ((conversionDirection === "g -> kg" || conversionDirection === "ml -> l") && value > 0.1) {
+  if (
+    (conversionDirection === "mg -> g" || conversionDirection === "g -> kg" || conversionDirection === "ml -> l") &&
+    value > 0.1
+  ) {
     return {
       unit: to,
       value: value / 1000,


### PR DESCRIPTION
### ✨ 페이지 뷰 - 마이페이지 / 하루 권장 영양소[#26](https://github.com/FRONT-END-BOOTCAMP-PLUS-3/haru-damu/issues/26) 구현을 완료하였습니다.

- 저번에 논의하던 값을 수정할 수 있는 부분을 토글로 해결했습니다.
  - 토글로 수정 불가능한 상태일 때
    - 추천 값으로 보여줌
    - 이 때, 커스텀 한 값은 지워지지 않음
  - 토글로 수정 가능한 상태일 때
    - 수정하던 값으로 보여줌 

- 원형 차트와 바 차트를 모두 사용하였습니다. 각각의 차트는 다음을 보여주고 있습니다.
  - 원형 차트
    - 현재 영양소 값들의 단위 비율
  - 바 차트
    - 현재 영양소 값이 권장 영양소에 비해 얼마나 차지하는 지 퍼센트로 제공

- 보윤님이 예쁘게 만들어주신 토스트를 처음으로 써봤습니다!! 감사합니다!!
  - api를 연결하기 시작하면서 try-catch문을 통해 사용자에게 알림을 보내기 위해 토스트를 사용하였습니다.
  - 그 과정에서 layout에 toast_container를 추가하였습니다.

- 상태값에 따라 그래프가 계속해서 추적합니다. 다만 데이터가 DB와 동기화 되는 순간은 다음에 한합니다.
  - 처음 페이지에 입장 할 때
  - 수정하기 버튼을 누를 때
  - 토글을 변경 할 때

### 형태

![Feb-06-2025 23-54-07](https://github.com/user-attachments/assets/ee944338-02ed-4e61-a69f-597dd8b99222)

### Interface

```typescript
export type TMypageNutrition = {
  key: string; // 영문 key
  label: string; // 한글 label
  unit: string; // 단위
  value: number; // 커스텀 값
  recommendValue: number; // 추천 값
};
```