### PR TITLE
feat : dto 정의 #69

### DIFF
--- a/application/usecases/carts/dtos/cart_dto.ts
+++ b/application/usecases/carts/dtos/cart_dto.ts
@@ -1,0 +1,13 @@
+import type { UUID } from "crypto";
+
+import type { ItemDto } from "../../items/dtos";
+
+export interface CartDto {
+  item_id: number;
+  item: ItemDto;
+  quantity: number;
+  wrapper_id: UUID;
+  is_checked: boolean;
+  created_at: string;
+  updated_at: string;
+}

--- a/application/usecases/carts/dtos/delete_cart_item_by_id_dto.ts
+++ b/application/usecases/carts/dtos/delete_cart_item_by_id_dto.ts
@@ -1,0 +1,10 @@
+// page : cart
+
+// DELETE
+export interface DeleteCartItemByIdRequestDto {
+  item_id: number;
+}
+
+export interface DeleteCartItemByIdResponseDto {
+  item_id: number;
+}

--- a/application/usecases/carts/dtos/get_cart_items_dto.ts
+++ b/application/usecases/carts/dtos/get_cart_items_dto.ts
@@ -1,0 +1,9 @@
+// page : cart
+
+import type { CartDto } from "@/application/usecases/carts/dtos";
+
+// GET
+export interface GetCartItemsResponseDto {
+  totalPrice: number;
+  items: CartDto[];
+}

--- a/application/usecases/carts/dtos/index.ts
+++ b/application/usecases/carts/dtos/index.ts
@@ -1,0 +1,4 @@
+export * from "@/application/usecases/carts/dtos/cart_dto";
+export * from "@/application/usecases/carts/dtos/get_cart_items_dto";
+export * from "@/application/usecases/carts/dtos/put_cart_items_dto";
+export * from "@/application/usecases/carts/dtos/delete_cart_item_by_id_dto";

--- a/application/usecases/carts/dtos/put_cart_items_dto.ts
+++ b/application/usecases/carts/dtos/put_cart_items_dto.ts
@@ -1,0 +1,11 @@
+// page : cart
+
+import type { CartDto } from "@/application/usecases/carts/dtos";
+
+export interface PutCartItemsRequestDto {
+  cart: CartDto[];
+}
+
+export interface PutCartItemsResponseDto {
+  cart: CartDto[];
+}

--- a/application/usecases/healths/dtos/get_health_dto.ts
+++ b/application/usecases/healths/dtos/get_health_dto.ts
@@ -1,0 +1,8 @@
+// page : mypage?health
+
+import type { HealthDto } from "@/application/usecases/healths/dtos";
+
+// GET
+export interface GetHealth {
+  health: HealthDto;
+}

--- a/application/usecases/healths/dtos/get_nutrition_dto.ts
+++ b/application/usecases/healths/dtos/get_nutrition_dto.ts
@@ -1,0 +1,10 @@
+// page : mypage?nutrition
+
+import type { HealthDto, NutritionDto } from "@/application/usecases/healths/dtos";
+
+// GET
+export interface GetNutritionResponseDto {
+  health: HealthDto;
+  customNutrition: NutritionDto;
+  recommendedNutrition: NutritionDto;
+}

--- a/application/usecases/healths/dtos/health_dto.ts
+++ b/application/usecases/healths/dtos/health_dto.ts
@@ -1,0 +1,19 @@
+// 0 : 매우 적음 | 1 : 가벼운 | 2 : 보통 | 3 : 활발한 | 4 : 매우 활발
+export type TActivityCode = 0 | 1 | 2 | 3 | 4;
+
+export interface HealthDto {
+  gender_code: "M" | "F";
+  age?: number;
+  weight?: number;
+  height?: number;
+  activity_code?: TActivityCode;
+  calorie?: number;
+  carbohydrates?: number;
+  protein?: number;
+  fat?: number;
+  sodium?: number;
+  sugar?: number;
+  is_custom: boolean;
+  created_at: string;
+  updated_at: string;
+}

--- a/application/usecases/healths/dtos/index.ts
+++ b/application/usecases/healths/dtos/index.ts
@@ -1,0 +1,6 @@
+export * from "@/application/usecases/healths/dtos/health_dto";
+export * from "@/application/usecases/healths/dtos/nutrition_dto";
+export * from "@/application/usecases/healths/dtos/get_health_dto";
+export * from "@/application/usecases/healths/dtos/put_health_dto";
+export * from "@/application/usecases/healths/dtos/get_nutrition_dto";
+export * from "@/application/usecases/healths/dtos/put_nutrition_dto";

--- a/application/usecases/healths/dtos/nutrition_dto.ts
+++ b/application/usecases/healths/dtos/nutrition_dto.ts
@@ -1,0 +1,9 @@
+export interface NutritionDto {
+  g?: number;
+  calorie?: number;
+  carbohydrates: number;
+  protein: number;
+  fat: number;
+  sodium: number;
+  sugar: number;
+}

--- a/application/usecases/healths/dtos/put_health_dto.ts
+++ b/application/usecases/healths/dtos/put_health_dto.ts
@@ -1,0 +1,12 @@
+// page : mypage?health
+
+import type { HealthDto } from "@/application/usecases/healths/dtos";
+
+// PUT
+export interface PutHealthRequestDto {
+  health: HealthDto;
+}
+
+export interface PutHealthResponseDto {
+  health: HealthDto;
+}

--- a/application/usecases/healths/dtos/put_nutrition_dto.ts
+++ b/application/usecases/healths/dtos/put_nutrition_dto.ts
@@ -1,0 +1,14 @@
+// page : mypage?nutrition
+
+import type { NutritionDto } from "@/application/usecases/healths/dtos";
+
+// PUT
+export interface PutNutritionRequestDto {
+  is_custom: boolean;
+  customNutrition: NutritionDto;
+}
+
+export interface PutNutritionResponseDto {
+  is_custom: boolean;
+  customNutrition: NutritionDto;
+}

--- a/application/usecases/items/dtos/get_item_by_id_dto.ts
+++ b/application/usecases/items/dtos/get_item_by_id_dto.ts
@@ -1,0 +1,8 @@
+// page : item/[:id]
+
+import type { ItemDto } from "@/application/usecases/items/dtos";
+
+// GET
+export interface GetItemById {
+  item: ItemDto;
+}

--- a/application/usecases/items/dtos/get_item_by_id_dto.ts
+++ b/application/usecases/items/dtos/get_item_by_id_dto.ts
@@ -4,5 +4,6 @@ import type { ItemDto } from "@/application/usecases/items/dtos";
 
 // GET
 export interface GetItemById {
+  item_id: string;
   item: ItemDto;
 }

--- a/application/usecases/items/dtos/get_item_list_dto.ts
+++ b/application/usecases/items/dtos/get_item_list_dto.ts
@@ -4,8 +4,9 @@ import type { ItemDto } from "@/application/usecases/items/dtos";
 
 // GET
 export interface GetItemListResponseDto {
-  total: number;
-  page: number;
-  size: number;
+  count: number; // 총 개수
+  totalPage: number; // 총 페이지
+  page: number; // 현재 페이지
+  size: number; // 한 페이지의 아이템 수
   items: ItemDto[];
 }

--- a/application/usecases/items/dtos/get_item_list_dto.ts
+++ b/application/usecases/items/dtos/get_item_list_dto.ts
@@ -1,0 +1,11 @@
+// page : search?, category?
+
+import type { ItemDto } from "@/application/usecases/items/dtos";
+
+// GET
+export interface GetItemListResponseDto {
+  total: number;
+  page: number;
+  size: number;
+  items: ItemDto[];
+}

--- a/application/usecases/items/dtos/get_main_items_dto.ts
+++ b/application/usecases/items/dtos/get_main_items_dto.ts
@@ -1,0 +1,10 @@
+// page : main
+
+import type { ItemDto } from "@/application/usecases/items/dtos";
+
+// GET
+export interface GetMainItemsResponseDto {
+  breakfast: ItemDto[];
+  lunch: ItemDto[];
+  dinner: ItemDto[];
+}

--- a/application/usecases/items/dtos/index.ts
+++ b/application/usecases/items/dtos/index.ts
@@ -1,0 +1,4 @@
+export * from "@/application/usecases/items/dtos/item_dto";
+export * from "@/application/usecases/items/dtos/get_main_items_dto";
+export * from "@/application/usecases/items/dtos/get_item_list_dto";
+export * from "@/application/usecases/items/dtos/get_item_by_id_dto";

--- a/application/usecases/items/dtos/item_dto.ts
+++ b/application/usecases/items/dtos/item_dto.ts
@@ -1,0 +1,25 @@
+import type { NutritionDto } from "@/application/usecases/healths/dtos";
+
+export type TCategoryCode = "bread" | "fish" | "meet" | "milk" | "side_dish" | "vegetable";
+
+// 0 : 판매 | 1 : 품절 | 2 : 삭제
+export type TItemCode = 0 | 1 | 2;
+
+export type TUnit = "mg" | "g" | "kg" | "ml" | "l" | "입";
+
+export interface ItemDto {
+  item_id: number;
+  store_id: number;
+  item_name: string;
+  item_price: string;
+  img: string | undefined;
+  blurImg: string | undefined;
+  description?: string;
+  category_code: TCategoryCode;
+  item_code: TItemCode;
+  unit_type: TUnit;
+  volume: number;
+  nutrition: NutritionDto;
+  created_at: string;
+  updated_at: string;
+}

--- a/application/usecases/orders/dtos/get_order_by_id.ts
+++ b/application/usecases/orders/dtos/get_order_by_id.ts
@@ -1,0 +1,8 @@
+// page : order/detail/[id]
+
+import type { OrderDto } from "@/application/usecases/orders/dtos";
+
+// GET
+export interface GetOrderByIdResponseDto {
+  order: OrderDto;
+}

--- a/application/usecases/orders/dtos/get_order_list_dto.ts
+++ b/application/usecases/orders/dtos/get_order_list_dto.ts
@@ -4,9 +4,10 @@ import type { OrderDto } from "@/application/usecases/orders/dtos";
 
 // GET
 export interface GetOrderListResponseDto {
-  total: number;
-  page: number;
-  year: number | null;
-  size: number;
+  count: number; // 총 개수
+  totalPage: number; // 총 페이지
+  page: number; // 현재 페이지
+  year: number | null; // 필터가 되는 년도 null일 경우 최근 6개월만
+  size: number; // 한 페이지 당 아이템 수
   items: OrderDto[];
 }

--- a/application/usecases/orders/dtos/get_order_list_dto.ts
+++ b/application/usecases/orders/dtos/get_order_list_dto.ts
@@ -1,0 +1,12 @@
+// page : mypage?order
+
+import type { OrderDto } from "@/application/usecases/orders/dtos";
+
+// GET
+export interface GetOrderListResponseDto {
+  total: number;
+  page: number;
+  year: number | null;
+  size: number;
+  items: OrderDto[];
+}

--- a/application/usecases/orders/dtos/index.ts
+++ b/application/usecases/orders/dtos/index.ts
@@ -1,0 +1,3 @@
+export * from "@/application/usecases/orders/dtos/order_dto";
+export * from "@/application/usecases/orders/dtos/get_order_by_id";
+export * from "@/application/usecases/orders/dtos/get_order_list_dto";

--- a/application/usecases/orders/dtos/order_dto.ts
+++ b/application/usecases/orders/dtos/order_dto.ts
@@ -1,0 +1,14 @@
+import type { CartDto } from "@/application/usecases/carts/dtos";
+
+// 0 : 결제전 | 1 : 결재 완료 | 2 : 배송준비중 | 3 : 배송중 | 4: 배송완료 | 5 : 주문취소 | 6: 반품
+export type TOrderStatus = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface OrderDto {
+  order_id: number;
+  order_address: string;
+  total_price: number;
+  order_list: CartDto[];
+  status: TOrderStatus;
+  created_at: string;
+  updated_at: string;
+}

--- a/application/usecases/users/dtos/get_personal_dto.ts
+++ b/application/usecases/users/dtos/get_personal_dto.ts
@@ -1,0 +1,8 @@
+// page : mypage?personal
+
+import type { UserDto } from "@/application/usecases/users/dtos";
+
+// GET
+export interface GetPersonalResponseDto {
+  user: UserDto;
+}

--- a/application/usecases/users/dtos/index.ts
+++ b/application/usecases/users/dtos/index.ts
@@ -1,0 +1,4 @@
+export * from "@/application/usecases/users/dtos/user_dto";
+export * from "@/application/usecases/users/dtos/login_dto";
+export * from "@/application/usecases/users/dtos/get_personal_dto";
+export * from "@/application/usecases/users/dtos/put_personal_dto";

--- a/application/usecases/users/dtos/login_dto.ts
+++ b/application/usecases/users/dtos/login_dto.ts
@@ -1,0 +1,8 @@
+// page : login
+
+import type { UserDto } from "@/application/usecases/users/dtos";
+
+// POST
+export interface LoginResponseDto {
+  user: UserDto;
+}

--- a/application/usecases/users/dtos/put_personal_dto.ts
+++ b/application/usecases/users/dtos/put_personal_dto.ts
@@ -3,6 +3,9 @@
 import type { UserDto } from "@/application/usecases/users/dtos";
 
 // PUT
+export interface PutPersonalRequestDto {
+  user: UserDto;
+}
 export interface PutPersonalResponseDto {
   user: UserDto;
 }

--- a/application/usecases/users/dtos/put_personal_dto.ts
+++ b/application/usecases/users/dtos/put_personal_dto.ts
@@ -1,0 +1,8 @@
+// page : mypage?personal
+
+import type { UserDto } from "@/application/usecases/users/dtos";
+
+// PUT
+export interface PutPersonalResponseDto {
+  user: UserDto;
+}

--- a/application/usecases/users/dtos/user_dto.ts
+++ b/application/usecases/users/dtos/user_dto.ts
@@ -1,0 +1,6 @@
+export interface UserDto {
+  name?: string;
+  address?: string;
+  email?: string;
+  phone?: string;
+}


### PR DESCRIPTION
# ✨  dto #69 를 정의 하였습니다.

### DTO의 구조 설명

`items/dto`를 기준으로 설명해보겠습니다.
- `repository`에서 `entity`에 맞는 데이터를 받아 가공하는 기본 데이터 구조가 `item_dto.ts` 입니다.
```typescript
// @/application/usecases/items/dtos/item_dto.ts

import type { NutritionDto } from "@/application/usecases/healths/dtos";

export type TCategoryCode = "bread" | "fish" | "meet" | "milk" | "side_dish" | "vegetable";

// 0 : 판매 | 1 : 품절 | 2 : 삭제
export type TItemCode = 0 | 1 | 2;

export type TUnit = "mg" | "g" | "kg" | "ml" | "l" | "입";

export interface ItemDto {
  item_id: number;
  store_id: number;
  item_name: string;
  item_price: string;
  img: string | undefined;
  blurImg: string | undefined;
  description?: string;
  category_code: TCategoryCode;
  item_code: TItemCode;
  unit_type: TUnit;
  volume: number;
  nutrition: NutritionDto;
  created_at: string;
  updated_at: string;
}

```
- 완전히 가공되어서 내보내 지는 형태는 각각의 `service` 명칭 따릅니다.
 ```typescript
 // @/application/usecases/items/dtos/get_item_list_dto.ts
 
 // page : search?, category?

import type { ItemDto } from "@/application/usecases/items/dtos";

// GET
export interface GetItemListResponseDto {
  count: number; // 총 개수
  totalPage: number; // 총 페이지
  page: number; // 현재 페이지
  size: number; // 한 페이지의 아이템 수
  items: ItemDto[];
} 
 ```
 - 각각의 dto들을 편하게 import하기 위해 한곳에 묶어줍니다. 이를 통해 import가 길어지는 것을 방지하고, 어떤 폴더에서 왔는 지 더 쉽게 확인할 수 있어 가독성이 올라갑니다.
 ```typescript
 // @/application/usecases/items/dtos/index.ts
 
export * from "@/application/usecases/items/dtos/item_dto";
export * from "@/application/usecases/items/dtos/get_main_items_dto";
export * from "@/application/usecases/items/dtos/get_item_list_dto";
export * from "@/application/usecases/items/dtos/get_item_by_id_dto";

// 여러 항목 import 시

import type { 
  ItemDto, 
  get_main_items_dto,
  get_item_list_dto
} from "@/application/usecases/items/dtos";
 ```

더 궁금한 부분이 있다면 코멘트 남겨주세요!

또, 부족한 부분이 있을 수 있어 첨언 환영입니다!!