### PR TITLE
Hotfix - 카트 / 주문서 #157

### DIFF
--- a/app/(main)/cart/_components/meal_cart.tsx
+++ b/app/(main)/cart/_components/meal_cart.tsx
@@ -10,11 +10,8 @@ import { useStore } from "@/hooks/usestore";
 
 import style from "@/app/(main)/cart/_components/meal_cart.module.css";
 
-import type { TItem, TNutrition } from "@/types";
 import type { TCartItem } from "@/stores/cart_store";
 
-import items from "@/dummys/items";
-import health from "@/dummys/health";
 import classNames from "classnames/bind";
 import { useDroppable } from "@dnd-kit/core";
 import { ArrowLeftCircle, ArrowRightCircle } from "lucide-react";
@@ -28,9 +25,7 @@ export default function MealCart() {
   const [totalPage, setTotalPage] = useState(1);
   const [carouselItems, setCarouselItems] = useState<TCartItem[]>([]);
 
-  const { mealCart, removeAllMealCartItems, wrappingMealItems } = useStore();
-
-  const { calorie, carbohydrates, protein, fat, sodium, sugar } = health;
+  const { mealCart, removeAllMealCartItems, wrappingMealItems, userNutrition } = useStore();
 
   const { setNodeRef } = useDroppable({
     id: "meal-cart-area",
@@ -41,17 +36,9 @@ export default function MealCart() {
 
   const isCarousel = mealCart.length > 4;
 
-  const userNutrition = {
-    calorie,
-    carbohydrates,
-    protein,
-    fat,
-    sodium,
-    sugar,
-  };
-
   const itemsNutrition = mealCart.map((cartItem) => {
-    const { g, calorie, carbohydrates, protein, fat, sodium, sugar } = cartItem.item.nutrition;
+    console.log(cartItem.item.nutrition);
+    const { g, carbohydrates, protein, fat, sodium, sugar, calorie } = cartItem.item.nutrition;
 
     return {
       g,
@@ -103,7 +90,7 @@ export default function MealCart() {
         />
       </div>
       <div className={cx("meal_cart__content__wrapper")}>
-        <MealCartChart userNutrition={userNutrition} itemsNutrition={itemsNutrition} />
+        <MealCartChart userNutrition={userNutrition } itemsNutrition={itemsNutrition} />
         <div className={cx("meal_cart__ul__wrapper")}>
           <button
             disabled={!isCarousel || page === 1}

--- a/app/(main)/cart/_components/meal_cart_chart.tsx
+++ b/app/(main)/cart/_components/meal_cart_chart.tsx
@@ -13,14 +13,25 @@ import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Tooltip, Lege
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend, ChartDataLabels);
 
 interface MealCartChartProps {
-  userNutrition: Omit<TNutrition, "g">;
+  userNutrition: Omit<TNutrition, "g" | "calorie">;
   itemsNutrition: TNutrition[];
 }
 
 export default function MealCartChart({ userNutrition, itemsNutrition }: MealCartChartProps) {
   const labels = HEALTH_CHART_DATA.map((data) => data.kor);
 
-  const nutritionKeys = Object.keys(userNutrition);
+  const userNutritionData =
+    !userNutrition.carbohydrates || userNutrition.carbohydrates === 0
+      ? {
+          carbohydrates: 70,
+          protein: 30,
+          fat: 20,
+          sodium: 800,
+          sugar: 15,
+        }
+      : userNutrition;
+
+  const nutritionKeys = Object.keys(userNutritionData);
 
   const sumItemsNutrition = (key: keyof TNutrition, itemsNutrition: TNutrition[]) => {
     return itemsNutrition.reduce((acc, cur) => {
@@ -34,7 +45,7 @@ export default function MealCartChart({ userNutrition, itemsNutrition }: MealCar
   };
 
   const mealNutrition = nutritionKeys.map((key) => {
-    const oneMeal = Math.floor(userNutrition[key as keyof Omit<TNutrition, "g">] / 3);
+    const oneMeal = Math.floor(userNutritionData[key as keyof Omit<TNutrition, "g" | "calorie">] / 3);
     const sumItems = Math.floor(sumItemsNutrition(key as keyof TNutrition, itemsNutrition));
     return {
       key,

--- a/app/(main)/mypage/page.tsx
+++ b/app/(main)/mypage/page.tsx
@@ -7,8 +7,6 @@ import { useStore } from "@/hooks/usestore";
 
 import styles from "./mypage.module.css";
 
-import user from "@/dummys/user";
-import health from "@/dummys/health";
 import classNames from "classnames/bind";
 
 const cx = classNames.bind(styles);
@@ -21,7 +19,7 @@ export default function MypagePage() {
       <div className={cx("mypage__wrapper", isShrunk && "mypage__wrapper__padding_top")}>
         {/* 왼쪽: UserAside 고정 */}
         <div className={cx("mypage__aside-wrapper")}>
-          <UserAside user={user} health={health} />
+          <UserAside />
         </div>
 
         {/* 오른쪽: 선택된 페이지 렌더링 */}

--- a/app/(main)/order/[id]/page.tsx
+++ b/app/(main)/order/[id]/page.tsx
@@ -26,6 +26,8 @@ export default async function OrderPage({ params }: { params: { id: string } }) 
 
   const fetchedData = order.orderList ?? [];
   const totalPrice = order.totalPrice;
+  const fetchedName = order.orderName;
+  const fetchedPhone = order.orderPhone;
   const fetchedAddress = order.orderAddress;
 
   const formattedPrice = totalPrice?.toLocaleString() ?? 0;
@@ -34,7 +36,7 @@ export default async function OrderPage({ params }: { params: { id: string } }) 
     <div className={cx("container")}>
       <h2 className={cx("order_title__h2", "title-lg-b")}>주문상세</h2>
       {fetchedData.length > 0 && <OrderItemSection items={fetchedData} totalPrice={formattedPrice} />}
-      <ShippingInfoSection fetchedAddress={fetchedAddress} />
+      <ShippingInfoSection fetchedName={fetchedName} fetchedPhone={fetchedPhone} fetchedAddress={fetchedAddress} />
       <PaymentInfoSection totalPrice={formattedPrice} />
     </div>
   );

--- a/app/(main)/order/[id]/page.tsx
+++ b/app/(main)/order/[id]/page.tsx
@@ -24,7 +24,7 @@ export default async function OrderPage({ params }: { params: { id: string } }) 
 
   const order = response.order;
 
-  const fetchedData = order.items ?? [];
+  const fetchedData = order.orderList ?? [];
   const totalPrice = order.totalPrice;
   const fetchedAddress = order.orderAddress;
 

--- a/app/(main)/order/[id]/page.tsx
+++ b/app/(main)/order/[id]/page.tsx
@@ -28,12 +28,14 @@ export default async function OrderPage({ params }: { params: { id: string } }) 
   const totalPrice = order.totalPrice;
   const fetchedAddress = order.orderAddress;
 
+  const formattedPrice = totalPrice?.toLocaleString() ?? 0;
+
   return (
     <div className={cx("container")}>
       <h2 className={cx("order_title__h2", "title-lg-b")}>주문상세</h2>
-      {fetchedData.length > 0 && <OrderItemSection items={fetchedData} totalPrice={totalPrice} />}
+      {fetchedData.length > 0 && <OrderItemSection items={fetchedData} totalPrice={formattedPrice} />}
       <ShippingInfoSection fetchedAddress={fetchedAddress} />
-      <PaymentInfoSection totalPrice={totalPrice} />
+      <PaymentInfoSection totalPrice={formattedPrice} />
     </div>
   );
 }

--- a/app/(main)/order/form/_components/payment_section.tsx
+++ b/app/(main)/order/form/_components/payment_section.tsx
@@ -32,6 +32,8 @@ export default function PaymentSection({ totalPrice, fetchedData }: PaymentInfoS
   const onClickHandler = async () => {
     try {
       const newOrder = {
+        orderName: user?.name,
+        orderPhone: user?.phone,
         orderAddress: user?.address,
         totalPrice,
         orderList: fetchedData,

--- a/app/(main)/order/form/_components/payment_section.tsx
+++ b/app/(main)/order/form/_components/payment_section.tsx
@@ -58,7 +58,7 @@ export default function PaymentSection({ totalPrice, fetchedData }: PaymentInfoS
 
       fetchCart([]);
 
-      router.push(`/order/${createOrder.order.orderId}`);
+      router.replace(`/order/${createOrder.order.orderId}`);
     } catch (error) {
       console.error(error);
     }

--- a/app/(main)/order/form/_components/payment_section.tsx
+++ b/app/(main)/order/form/_components/payment_section.tsx
@@ -70,7 +70,7 @@ export default function PaymentSection({ totalPrice, fetchedData }: PaymentInfoS
       <LabelValueText label={"결제수단 선택"} />
       <PaymentButtonList payments={PAYMENTS} />
       <Button
-        text={`${totalPrice} 원 결제하기`}
+        text={`${totalPrice?.toLocaleString() ?? 0} 원 결제하기`}
         color="primary"
         width="252px"
         height="60px"

--- a/app/(main)/order/form/page.tsx
+++ b/app/(main)/order/form/page.tsx
@@ -29,17 +29,16 @@ export default async function OrderFormPage() {
   const isCheckedItems = fetchedData?.filter((item: TCartItem) => item.isChecked);
 
   const totalPrice = response.totalPrice;
-  const formattedPrice = totalPrice?.toLocaleString() ?? 0;
 
   if (response.count === 0) redirect("/");
 
   return (
     <div className={cx("container")}>
       <h2 className={cx("order_form_title__h2", "title-lg-b")}>주문서</h2>
-      <OrderItemSection items={isCheckedItems} totalPrice={formattedPrice} />
+      <OrderItemSection items={isCheckedItems} totalPrice={totalPrice} />
       <OrdererInfoSection />
       <ShippingInfoSection />
-      <PaymentSection totalPrice={formattedPrice} fetchedData={isCheckedItems} />
+      <PaymentSection totalPrice={totalPrice} fetchedData={isCheckedItems} />
     </div>
   );
 }

--- a/app/(main)/order/form/page.tsx
+++ b/app/(main)/order/form/page.tsx
@@ -26,15 +26,17 @@ export default async function OrderFormPage() {
   const fetchedData = response.items;
   const totalPrice = response.totalPrice;
 
+  const formattedPrice = totalPrice?.toLocaleString() ?? 0;
+
   if (response.count === 0) redirect("/");
 
   return (
     <div className={cx("container")}>
       <h2 className={cx("order_form_title__h2", "title-lg-b")}>주문서</h2>
-      <OrderItemSection items={fetchedData} totalPrice={totalPrice} />
+      <OrderItemSection items={fetchedData} totalPrice={formattedPrice} />
       <OrdererInfoSection />
       <ShippingInfoSection />
-      <PaymentSection totalPrice={totalPrice} fetchedData={fetchedData} />
+      <PaymentSection totalPrice={formattedPrice} fetchedData={fetchedData} />
     </div>
   );
 }

--- a/app/(main)/order/form/page.tsx
+++ b/app/(main)/order/form/page.tsx
@@ -9,6 +9,8 @@ import getHeader from "@/utils/get_header";
 
 import styles from "@/app/(main)/order/form/page.module.css";
 
+import type { TCartItem } from "@/stores/cart_store";
+
 import classNames from "classnames/bind";
 
 const cx = classNames.bind(styles);
@@ -24,8 +26,9 @@ export default async function OrderFormPage() {
   }).then((response) => response.json());
 
   const fetchedData = response.items;
-  const totalPrice = response.totalPrice;
+  const isCheckedItems = fetchedData?.filter((item: TCartItem) => item.isChecked);
 
+  const totalPrice = response.totalPrice;
   const formattedPrice = totalPrice?.toLocaleString() ?? 0;
 
   if (response.count === 0) redirect("/");
@@ -33,10 +36,10 @@ export default async function OrderFormPage() {
   return (
     <div className={cx("container")}>
       <h2 className={cx("order_form_title__h2", "title-lg-b")}>주문서</h2>
-      <OrderItemSection items={fetchedData} totalPrice={formattedPrice} />
+      <OrderItemSection items={isCheckedItems} totalPrice={formattedPrice} />
       <OrdererInfoSection />
       <ShippingInfoSection />
-      <PaymentSection totalPrice={formattedPrice} fetchedData={fetchedData} />
+      <PaymentSection totalPrice={formattedPrice} fetchedData={isCheckedItems} />
     </div>
   );
 }

--- a/components/common/header.tsx
+++ b/components/common/header.tsx
@@ -4,8 +4,6 @@ import { useRouter } from "next/navigation";
 
 import { useEffect, useCallback } from "react";
 
-import { createPortal } from "react-dom";
-
 import SearchBar from "@/components/searchbar";
 import CategoryList from "@/components/category_list";
 import MealInfoModal from "@/components/meal_info_modal";

--- a/components/order_item_section.tsx
+++ b/components/order_item_section.tsx
@@ -20,7 +20,7 @@ const cx = classNames.bind(styles);
 export default function OrderItemSection({ items = [], totalPrice }: OrderItemSectionProps) {
   const pathname = usePathname();
   const isOrderForm = pathname === "/order/form";
-  
+
   return (
     <section>
       <Subheading title={"주문 상품"} />
@@ -32,7 +32,7 @@ export default function OrderItemSection({ items = [], totalPrice }: OrderItemSe
         <div className={cx("order_item_section_total_price")}>
           <span>최종 결제 금액</span>
           <div className={cx("order_item_section_total_price__div")}>
-            <p className={cx("title-md-b")}>{totalPrice}</p>
+            <p className={cx("title-md-b")}>{totalPrice?.toLocaleString() ?? 0}</p>
             <span>원</span>
           </div>
         </div>

--- a/components/shipping_info_section.tsx
+++ b/components/shipping_info_section.tsx
@@ -6,19 +6,23 @@ import LabelValueText from "@/components/common/label_value_text";
 import { useStore } from "@/hooks/usestore";
 
 interface ShippingInfoSectionProps {
+  fetchedName?: string;
+  fetchedPhone?: string;
   fetchedAddress?: string;
 }
 
-export default function ShippingInfoSection({ fetchedAddress }: ShippingInfoSectionProps) {
+export default function ShippingInfoSection({ fetchedName, fetchedPhone, fetchedAddress }: ShippingInfoSectionProps) {
   const { user } = useStore();
 
+  const name = fetchedName ?? user?.name;
+  const phone = fetchedPhone ?? user?.phone;
   const address = fetchedAddress ?? user?.address;
 
   return (
     <section>
       <Subheading title={"배송 정보"} />
-      <LabelValueText label={"주문자"} value={user?.name} />
-      <LabelValueText label={"휴대폰"} value={user?.phone} />
+      <LabelValueText label={"주문자"} value={name} />
+      <LabelValueText label={"휴대폰"} value={phone} />
       <LabelValueText label={"배송지"} value={address} />
     </section>
   );

--- a/stores/cart_store.ts
+++ b/stores/cart_store.ts
@@ -1,11 +1,13 @@
 import { uuidGenerator } from "@/utils/uuid_generator";
 
+import type { TItem } from "@/types";
 import type { StateCreator } from "zustand";
 import type { State } from "@/hooks/usestore";
 
 export type TCartItem = {
   itemId: number;
   userId: number;
+  item: TItem;
   itemName: string;
   itemPrice: number;
   img: string | undefined;


### PR DESCRIPTION
Hotfix - 카트 / 주문서[#157](https://github.com/FRONT-END-BOOTCAMP-PLUS-3/haru-damu/issues/157)

#146 
#147 
#145 

### 카트
- [x] 주문 시 모든 카트가 다 이동한다 (체크한것만으로 안됨)
### 주문서 / 주문 상세
- [x] 주문완료 후 주문서에서 돌아가기 버튼 누르니 주문폼으로 돌아간다
- [x] 주문 내역 아이템이 안보임
- [x] 회원 order에 주문자와 휴대폰 번호가 회원정보와 동기화 되어있다.
- [x] 결제 금액 단위가 안나뉘어 있다